### PR TITLE
fix(bridge): bound SendAndReceive with a 10-minute per-message timeout

### DIFF
--- a/cmd/kapso-whatsapp-bridge/main.go
+++ b/cmd/kapso-whatsapp-bridge/main.go
@@ -283,7 +283,10 @@ func handleMessage(ctx context.Context, gw gateway.Gateway, client *kapso.Client
 
 	log.Printf("forwarded message %s from %s [role: %s, session: %s]", evt.ID, evt.From, role, sessionKey)
 
-	reply, err := gw.SendAndReceive(ctx, &gateway.Request{
+	msgCtx, msgCancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer msgCancel()
+
+	reply, err := gw.SendAndReceive(msgCtx, &gateway.Request{
 		SessionKey:     sessionKey,
 		IdempotencyKey: evt.ID,
 		From:           evt.From,


### PR DESCRIPTION
## Summary

- `handleMessage` passes the root bridge context directly into `SendAndReceive`, which means a stalled gateway (ZeroClaw freezing mid-response) blocks the goroutine indefinitely — the WhatsApp typing indicator keeps spinning and no reply ever arrives
- Wraps `SendAndReceive` with a `context.WithTimeout(ctx, 10*time.Minute)` so every message has a hard upper bound
- On timeout: the context error propagates back through `SendAndReceive`, the ZeroClaw gateway evicts the broken connection, the typing indicator stops, and the next message from that sender opens a fresh connection

## Why 10 minutes

Matches the OpenClaw gateway's own polling timeout (`deadline := time.Now().Add(10 * time.Minute)`). Kiro is configured with `max_tool_iterations = 40`, and a normal response well within this window.

## What changed

`cmd/kapso-whatsapp-bridge/main.go` — two lines in `handleMessage`:

```go
msgCtx, msgCancel := context.WithTimeout(ctx, 10*time.Minute)
defer msgCancel()
// pass msgCtx instead of ctx to SendAndReceive
```

## Test plan

- [x] Full test suite passes
- [x] Builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)