### PR TITLE
fix: advance poll cursor for all message types

### DIFF
--- a/internal/delivery/poller/poller.go
+++ b/internal/delivery/poller/poller.go
@@ -75,6 +75,14 @@ func (p *Poller) poll(lastPoll *time.Time, out chan<- delivery.Event) {
 	forwarded := 0
 
 	for _, msg := range resp.Data {
+		// Track timestamp for ALL messages so the cursor advances past
+		// unsupported types (stickers, contacts, etc.) and they are not
+		// re-fetched on the next poll cycle.
+		msgTime := parseTimestamp(msg.Timestamp)
+		if !msgTime.IsZero() && msgTime.After(newest) {
+			newest = msgTime
+		}
+
 		text, ok := delivery.ExtractText(msg.Message, p.Client, p.Transcriber, p.MaxAudioSize)
 		if !ok {
 			continue
@@ -92,11 +100,6 @@ func (p *Poller) poll(lastPoll *time.Time, out chan<- delivery.Event) {
 			Text: text,
 		}
 		forwarded++
-
-		msgTime := parseTimestamp(msg.Timestamp)
-		if !msgTime.IsZero() && msgTime.After(newest) {
-			newest = msgTime
-		}
 	}
 
 	if forwarded > 0 {


### PR DESCRIPTION
## Summary

Move timestamp tracking **before** `ExtractText()` check in `poll()` so the `lastPoll` cursor advances past unsupported message types (stickers, contacts, etc.)

## Problem

When an unsupported message (sticker, contact, etc.) is received, `ExtractText()` returns `ok=false` and the loop `continue`s — but timestamp tracking is after that point, so `newest` is never updated. The poller re-fetches the same message every cycle (~30s), creating an infinite reply loop.

## Fix

4 lines moved: `parseTimestamp` + `newest` update relocated from after `ExtractText`/`continue` to before it. No other logic changed.

```go
// Before: timestamp tracking after ExtractText → unsupported msgs never advance cursor
for _, msg := range resp.Data {
    text, ok := delivery.ExtractText(...)
    if !ok { continue }
    // ... forward ...
    msgTime := parseTimestamp(msg.Timestamp)  // never reached for stickers
}

// After: timestamp tracking before ExtractText → cursor advances for ALL messages
for _, msg := range resp.Data {
    msgTime := parseTimestamp(msg.Timestamp)  // always reached
    if !msgTime.IsZero() && msgTime.After(newest) { newest = msgTime }
    text, ok := delivery.ExtractText(...)
    if !ok { continue }
    // ... forward ...
}
```

## Test plan

- [ ] Send a sticker → only ONE "Sorry" reply (no loop)
- [ ] Send text after sticker → processes normally
- [ ] Verify `last-poll` state file advances past sticker timestamp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message delivery polling now correctly advances through all message types, including unsupported formats, preventing processing delays and ensuring consistent message handling flow.

* **Refactor**
  * Streamlined polling logic by removing redundant timestamp update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->