### PR TITLE
fix: parse release tags without v prefix

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -49,7 +49,7 @@ if [ -z "$TAG" ]; then
   if command -v jq >/dev/null 2>&1; then
     TAG="$(echo "$api_response" | jq -r '.tag_name')"
   else
-    TAG="$(echo "$api_response" | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/' | head -n 1)"
+    TAG="$(echo "$api_response" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n 1)"
   fi
 fi
 


### PR DESCRIPTION
## Summary
- make the install script fallback parser accept release tags with or without a `v` prefix

## Explanation

Given that the current and latests release doesn't have a v at the beginning the current install bash file is failing. Added a simple edit to avoid failing whenever latests release doesnt have a v at the beginning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the installation script's version detection mechanism to more reliably identify and retrieve release versions, ensuring accurate and consistent installations across systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->