### PR TITLE
fix: strip OpenClaw directive tags from outbound messages

### DIFF
--- a/internal/gateway/format.go
+++ b/internal/gateway/format.go
@@ -7,6 +7,10 @@ import (
 
 // Compiled regexes for mdToWhatsApp compiled once at startup.
 var (
+	// reDirective strips OpenClaw internal directive tags that should not
+	// appear in user-visible messages (e.g. [[reply_to_current]],
+	// [[reply_to:<id>]], [[audio_as_voice]]).
+	reDirective  = regexp.MustCompile(`\[\[\s*(?:reply_to_current|reply_to_previous|reply_to\s*:\s*[^\]\n]+|audio_as_voice)\s*\]\]\s*`)
 	reBold       = regexp.MustCompile(`\*\*(.+?)\*\*`)
 	reItalic     = regexp.MustCompile(`\*(.+?)\*`)
 	reStrike     = regexp.MustCompile(`~~(.+?)~~`)
@@ -17,6 +21,9 @@ var (
 // MdToWhatsApp converts Markdown formatting to WhatsApp-compatible formatting.
 func MdToWhatsApp(text string) string {
 	const boldMarker = "\x01"
+
+	// Strip internal directive tags before any formatting.
+	text = reDirective.ReplaceAllString(text, "")
 
 	result := reBold.ReplaceAllString(text, boldMarker+"$1"+boldMarker)
 	result = reItalic.ReplaceAllString(result, "_$1_")

--- a/internal/gateway/format_test.go
+++ b/internal/gateway/format_test.go
@@ -1,0 +1,124 @@
+package gateway
+
+import (
+	"testing"
+)
+
+func TestMdToWhatsApp(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "bold",
+			input: "this is **bold** text",
+			want:  "this is *bold* text",
+		},
+		{
+			name:  "italic standalone",
+			input: "this is _italic_ text",
+			want:  "this is _italic_ text",
+		},
+		{
+			name:  "strikethrough",
+			input: "this is ~~struck~~ text",
+			want:  "this is ~struck~ text",
+		},
+		{
+			name:  "heading",
+			input: "## My Heading",
+			want:  "*My Heading*",
+		},
+		{
+			name:  "blockquote removed",
+			input: "> quoted text",
+			want:  "quoted text",
+		},
+		{
+			name:  "strip reply_to_current",
+			input: "[[reply_to_current]] Hello!",
+			want:  "Hello!",
+		},
+		{
+			name:  "strip reply_to_current with extra spaces",
+			input: "[[ reply_to_current ]] Hello!",
+			want:  "Hello!",
+		},
+		{
+			name:  "strip reply_to_previous",
+			input: "[[reply_to_previous]] Hello!",
+			want:  "Hello!",
+		},
+		{
+			name:  "strip reply_to with id",
+			input: "[[reply_to:msg-123]] Hello!",
+			want:  "Hello!",
+		},
+		{
+			name:  "strip reply_to with id and spaces",
+			input: "[[ reply_to: msg-123 ]] Hello!",
+			want:  "Hello!",
+		},
+		{
+			name:  "strip audio_as_voice",
+			input: "[[audio_as_voice]] Here is the audio",
+			want:  "Here is the audio",
+		},
+		{
+			name:  "strip directive with formatting",
+			input: "[[reply_to_current]] ✅ **Done.** Check it out.",
+			want:  "✅ *Done.* Check it out.",
+		},
+		{
+			name:  "no directive passthrough",
+			input: "Just a normal message",
+			want:  "Just a normal message",
+		},
+		{
+			name:  "preserve non-directive brackets",
+			input: "[not a directive] hello",
+			want:  "[not a directive] hello",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MdToWhatsApp(tt.input)
+			if got != tt.want {
+				t.Errorf("MdToWhatsApp(%q)\n got: %q\nwant: %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitMessage(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		maxLen int
+		want   int // expected number of chunks
+	}{
+		{
+			name:   "short message no split",
+			input:  "hello",
+			maxLen: 100,
+			want:   1,
+		},
+		{
+			name:   "long message splits",
+			input:  "word " + string(make([]byte, 200)),
+			maxLen: 100,
+			want:   3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SplitMessage(tt.input, tt.maxLen)
+			if len(got) != tt.want {
+				t.Errorf("SplitMessage() returned %d chunks, want %d", len(got), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Strip `[[reply_to_current]]`, `[[reply_to_previous]]`, `[[reply_to:<id>]]`, and `[[audio_as_voice]]` directive tags from outbound WhatsApp messages in `MdToWhatsApp()`
- OpenClaw's system prompt instructs the model to emit these tags for internal threading. The native WhatsApp channel strips them, but the Kapso bridge forwards raw session JSONL text — causing tags to appear verbatim in user messages
- Adds `format_test.go` with table-driven tests covering all tag variants, markdown formatting, and edge cases

## Test plan
- [x] All new tests pass (`go test ./internal/gateway/ -v`)
- [x] Verified fix resolves the issue on a live OpenClaw + Kapso deployment
- [ ] Existing CI should pass (no breaking changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved message processing by removing internal directive patterns (reply references and audio markers) from messages before they are formatted for WhatsApp delivery, ensuring cleaner message output.

* **Tests**
  * Added comprehensive test coverage for message formatting and splitting logic, validating proper transformation of messages and correct handling of message length constraints for WhatsApp delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->