### PR TITLE
feat: Ed25519 device identity for protocol v3 handshake

### DIFF
--- a/cmd/kapso-whatsapp-bridge/main.go
+++ b/cmd/kapso-whatsapp-bridge/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Enriquefft/openclaw-kapso-whatsapp/internal/commands"
 	"github.com/Enriquefft/openclaw-kapso-whatsapp/internal/config"
 	"github.com/Enriquefft/openclaw-kapso-whatsapp/internal/delivery"
+	"github.com/Enriquefft/openclaw-kapso-whatsapp/internal/device"
 	"github.com/Enriquefft/openclaw-kapso-whatsapp/internal/delivery/poller"
 	"github.com/Enriquefft/openclaw-kapso-whatsapp/internal/delivery/webhook"
 	"github.com/Enriquefft/openclaw-kapso-whatsapp/internal/gateway"
@@ -51,8 +52,15 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Load or create device identity for gateway authentication.
+	ident, err := device.LoadOrCreate(cfg.State.Dir)
+	if err != nil {
+		log.Fatalf("device identity: %v", err)
+	}
+	log.Printf("device: id=%s", ident.DeviceID()[:16])
+
 	// Connect to the AI gateway (OpenClaw, ZeroClaw, etc.).
-	gw, err := gateway.New(cfg.Gateway)
+	gw, err := gateway.New(cfg.Gateway, gateway.WithSigner(ident))
 	if err != nil {
 		log.Fatalf("invalid gateway config: %v", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,6 +151,7 @@ func Load() (*Config, error) {
 	}
 
 	applyEnv(&cfg)
+	expandPaths(&cfg)
 	return &cfg, nil
 }
 
@@ -404,6 +405,13 @@ func phoneInRoles(roles map[string][]string, phone string) bool {
 		}
 	}
 	return false
+}
+
+func expandPaths(cfg *Config) {
+	cfg.Gateway.SessionsJSON = expandHome(cfg.Gateway.SessionsJSON)
+	cfg.State.Dir = expandHome(cfg.State.Dir)
+	cfg.Transcribe.BinaryPath = expandHome(cfg.Transcribe.BinaryPath)
+	cfg.Transcribe.ModelPath = expandHome(cfg.Transcribe.ModelPath)
 }
 
 func expandHome(path string) string {

--- a/internal/device/identity.go
+++ b/internal/device/identity.go
@@ -1,31 +1,25 @@
 package device
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/sha256"
-	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
-	"time"
 )
 
 const keyFile = "device-key.pem"
 
-// Identity holds a persistent ECDSA P-256 keypair used to prove device
-// identity to the OpenClaw gateway.
 type Identity struct {
-	key    *ecdsa.PrivateKey
-	pubDER []byte // pre-computed DER-encoded public key
+	key ed25519.PrivateKey
+	pub ed25519.PublicKey
 }
 
-// LoadOrCreate reads an existing device key from dir, or generates a new
-// P-256 key and persists it. The directory is created if it does not exist.
 func LoadOrCreate(dir string) (*Identity, error) {
 	path := filepath.Join(dir, keyFile)
 
@@ -33,17 +27,16 @@ func LoadOrCreate(dir string) (*Identity, error) {
 	if err == nil {
 		key, parseErr := parseKey(data)
 		if parseErr != nil {
-			return nil, fmt.Errorf("parse device key %s: %w", path, parseErr)
+			log.Printf("device: removing incompatible key at %s (%v), generating new Ed25519 key", path, parseErr)
+			_ = os.Remove(path)
+		} else {
+			return &Identity{key: key, pub: key.Public().(ed25519.PublicKey)}, nil
 		}
-		return newIdentity(key)
-	}
-
-	if !os.IsNotExist(err) {
+	} else if !os.IsNotExist(err) {
 		return nil, fmt.Errorf("read device key %s: %w", path, err)
 	}
 
-	// Generate new key.
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("generate device key: %w", err)
 	}
@@ -52,59 +45,39 @@ func LoadOrCreate(dir string) (*Identity, error) {
 		return nil, fmt.Errorf("create state dir %s: %w", dir, err)
 	}
 
-	derBytes, err := x509.MarshalECPrivateKey(key)
-	if err != nil {
-		return nil, fmt.Errorf("marshal device key: %w", err)
-	}
-
 	pemBlock := pem.EncodeToMemory(&pem.Block{
-		Type:  "EC PRIVATE KEY",
-		Bytes: derBytes,
+		Type:  "PRIVATE KEY",
+		Bytes: priv.Seed(),
 	})
 
 	if err := os.WriteFile(path, pemBlock, 0o600); err != nil {
 		return nil, fmt.Errorf("write device key %s: %w", path, err)
 	}
 
-	return newIdentity(key)
+	return &Identity{key: priv, pub: pub}, nil
 }
 
-func newIdentity(key *ecdsa.PrivateKey) (*Identity, error) {
-	pub, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
-	if err != nil {
-		return nil, fmt.Errorf("marshal public key: %w", err)
-	}
-	return &Identity{key: key, pubDER: pub}, nil
-}
-
-// DeviceID returns a hex-encoded SHA-256 fingerprint of the public key.
 func (id *Identity) DeviceID() string {
-	h := sha256.Sum256(id.pubDER)
+	h := sha256.Sum256(id.pub)
 	return hex.EncodeToString(h[:])
 }
 
-// PublicKeyBase64 returns the base64-encoded DER public key.
 func (id *Identity) PublicKeyBase64() string {
-	return base64.StdEncoding.EncodeToString(id.pubDER)
+	return base64.RawURLEncoding.EncodeToString(id.pub)
 }
 
-// Sign signs the given nonce with the device private key and returns the
-// base64-encoded ASN.1 DER signature plus the signing timestamp (Unix ms).
-func (id *Identity) Sign(nonce string) (signature string, signedAt int64, err error) {
-	h := sha256.Sum256([]byte(nonce))
-	sig, err := ecdsa.SignASN1(rand.Reader, id.key, h[:])
-	if err != nil {
-		return "", 0, fmt.Errorf("sign nonce: %w", err)
-	}
-
-	now := time.Now().UnixMilli()
-	return base64.StdEncoding.EncodeToString(sig), now, nil
+func (id *Identity) Sign(data []byte) []byte {
+	return ed25519.Sign(id.key, data)
 }
 
-func parseKey(data []byte) (*ecdsa.PrivateKey, error) {
+func parseKey(data []byte) (ed25519.PrivateKey, error) {
 	block, _ := pem.Decode(data)
 	if block == nil {
 		return nil, fmt.Errorf("no PEM block found")
 	}
-	return x509.ParseECPrivateKey(block.Bytes)
+	seed := block.Bytes
+	if len(seed) != ed25519.SeedSize {
+		return nil, fmt.Errorf("invalid Ed25519 seed length: %d", len(seed))
+	}
+	return ed25519.NewKeyFromSeed(seed), nil
 }

--- a/internal/device/identity_test.go
+++ b/internal/device/identity_test.go
@@ -1,191 +1,99 @@
 package device
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/sha256"
-	"crypto/x509"
+	"crypto/ed25519"
 	"encoding/base64"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
-// TestLoadOrCreateGeneratesKey verifies that LoadOrCreate creates a new key
-// when none exists and that the key file is persisted.
 func TestLoadOrCreateGeneratesKey(t *testing.T) {
 	dir := t.TempDir()
-
 	id, err := LoadOrCreate(dir)
 	if err != nil {
 		t.Fatalf("LoadOrCreate() error: %v", err)
 	}
-
 	if id.key == nil {
 		t.Fatal("key should not be nil")
 	}
-
-	// Key file should exist on disk.
 	path := filepath.Join(dir, keyFile)
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("key file not written: %v", err)
 	}
 }
 
-// TestLoadOrCreateReusesKey verifies that calling LoadOrCreate twice returns
-// the same key — persistence is working, not regenerating each time.
 func TestLoadOrCreateReusesKey(t *testing.T) {
 	dir := t.TempDir()
-
 	id1, err := LoadOrCreate(dir)
 	if err != nil {
 		t.Fatalf("first LoadOrCreate: %v", err)
 	}
-
 	id2, err := LoadOrCreate(dir)
 	if err != nil {
 		t.Fatalf("second LoadOrCreate: %v", err)
 	}
-
 	if id1.DeviceID() != id2.DeviceID() {
-		t.Errorf("device IDs differ: %s vs %s — key was regenerated", id1.DeviceID(), id2.DeviceID())
+		t.Errorf("device IDs differ: %s vs %s", id1.DeviceID(), id2.DeviceID())
 	}
 }
 
-// TestDeviceIDDeterministic verifies DeviceID is stable across calls.
 func TestDeviceIDDeterministic(t *testing.T) {
 	dir := t.TempDir()
 	id, err := LoadOrCreate(dir)
 	if err != nil {
 		t.Fatalf("LoadOrCreate: %v", err)
 	}
-
 	a := id.DeviceID()
 	b := id.DeviceID()
 	if a != b {
 		t.Errorf("DeviceID not deterministic: %q vs %q", a, b)
 	}
-
 	if len(a) != 64 {
-		t.Errorf("DeviceID should be 64 hex chars (SHA-256), got %d", len(a))
+		t.Errorf("DeviceID should be 64 hex chars, got %d", len(a))
 	}
 }
 
-// TestPublicKeyBase64Decodable verifies that PublicKeyBase64 returns a valid
-// base64-encoded DER public key that can be parsed back.
 func TestPublicKeyBase64Decodable(t *testing.T) {
 	dir := t.TempDir()
 	id, err := LoadOrCreate(dir)
 	if err != nil {
 		t.Fatalf("LoadOrCreate: %v", err)
 	}
-
 	b64 := id.PublicKeyBase64()
-	der, err := base64.StdEncoding.DecodeString(b64)
+	pub, err := base64.RawURLEncoding.DecodeString(b64)
 	if err != nil {
-		t.Fatalf("base64 decode: %v", err)
+		t.Fatalf("base64url decode: %v", err)
 	}
-
-	pub, err := x509.ParsePKIXPublicKey(der)
-	if err != nil {
-		t.Fatalf("parse public key: %v", err)
-	}
-
-	if _, ok := pub.(*ecdsa.PublicKey); !ok {
-		t.Fatalf("expected *ecdsa.PublicKey, got %T", pub)
+	if len(pub) != ed25519.PublicKeySize {
+		t.Fatalf("expected %d byte public key, got %d", ed25519.PublicKeySize, len(pub))
 	}
 }
 
-// TestSignProducesVerifiableSignature verifies that Sign produces a signature
-// that can be verified with the public key.
 func TestSignProducesVerifiableSignature(t *testing.T) {
 	dir := t.TempDir()
 	id, err := LoadOrCreate(dir)
 	if err != nil {
 		t.Fatalf("LoadOrCreate: %v", err)
 	}
-
-	nonce := "test-challenge-nonce-42"
-	sig64, signedAt, err := id.Sign(nonce)
-	if err != nil {
-		t.Fatalf("Sign() error: %v", err)
-	}
-
-	if signedAt <= 0 {
-		t.Errorf("signedAt should be positive, got %d", signedAt)
-	}
-
-	sigDER, err := base64.StdEncoding.DecodeString(sig64)
-	if err != nil {
-		t.Fatalf("decode signature: %v", err)
-	}
-
-	h := sha256.Sum256([]byte(nonce))
-	if !ecdsa.VerifyASN1(&id.key.PublicKey, h[:], sigDER) {
+	payload := []byte("v3|test|client|backend|operator|operator.read,operator.write|1234567890|token|nonce|darwin|")
+	sig := id.Sign(payload)
+	if !ed25519.Verify(id.pub, payload, sig) {
 		t.Fatal("signature verification failed")
 	}
 }
 
-// TestSignDifferentNoncesProduceDifferentSignatures verifies that signing
-// different nonces produces different signatures.
-func TestSignDifferentNoncesProduceDifferentSignatures(t *testing.T) {
-	dir := t.TempDir()
-	id, err := LoadOrCreate(dir)
-	if err != nil {
-		t.Fatalf("LoadOrCreate: %v", err)
-	}
-
-	sig1, _, _ := id.Sign("nonce-1")
-	sig2, _, _ := id.Sign("nonce-2")
-
-	if sig1 == sig2 {
-		t.Error("different nonces produced identical signatures")
-	}
-}
-
-// TestLoadOrCreateCreatesDirectory verifies that LoadOrCreate creates the
-// state directory if it does not exist.
-func TestLoadOrCreateCreatesDirectory(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "nested", "path")
-
-	_, err := LoadOrCreate(dir)
-	if err != nil {
-		t.Fatalf("LoadOrCreate with nested dir: %v", err)
-	}
-
-	info, err := os.Stat(dir)
-	if err != nil {
-		t.Fatalf("directory not created: %v", err)
-	}
-	if !info.IsDir() {
-		t.Fatal("expected directory")
-	}
-}
-
-// TestLoadOrCreateRejectsCorruptKey verifies that a corrupt key file is
-// reported as an error.
-func TestLoadOrCreateRejectsCorruptKey(t *testing.T) {
+func TestLoadOrCreateRegeneratesCorruptKey(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, keyFile)
 	if err := os.WriteFile(path, []byte("not a pem file"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-
-	_, err := LoadOrCreate(dir)
-	if err == nil {
-		t.Fatal("expected error for corrupt key file")
-	}
-}
-
-// TestLoadOrCreateP256Curve verifies the generated key uses P-256.
-func TestLoadOrCreateP256Curve(t *testing.T) {
-	dir := t.TempDir()
 	id, err := LoadOrCreate(dir)
 	if err != nil {
-		t.Fatalf("LoadOrCreate: %v", err)
+		t.Fatalf("expected auto-regeneration, got error: %v", err)
 	}
-
-	if id.key.Curve != elliptic.P256() {
-		t.Errorf("expected P-256 curve, got %v", id.key.Curve.Params().Name)
+	if id.key == nil {
+		t.Fatal("key should not be nil after regeneration")
 	}
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -32,13 +32,32 @@ type Request struct {
 }
 
 // New creates the appropriate Gateway for the configured type.
-func New(cfg config.GatewayConfig) (Gateway, error) {
+func New(cfg config.GatewayConfig, opts ...Option) (Gateway, error) {
+	var o options
+	for _, fn := range opts {
+		fn(&o)
+	}
 	switch cfg.Type {
 	case "", "openclaw":
+		if o.signer != nil {
+			return NewOpenClawWithSigner(cfg, o.signer), nil
+		}
 		return NewOpenClaw(cfg), nil
 	case "zeroclaw":
 		return NewZeroClaw(cfg), nil
 	default:
 		return nil, fmt.Errorf("unknown gateway type: %q", cfg.Type)
 	}
+}
+
+type options struct {
+	signer Signer
+}
+
+// Option configures gateway construction.
+type Option func(*options)
+
+// WithSigner attaches a device identity signer to the gateway.
+func WithSigner(s Signer) Option {
+	return func(o *options) { o.signer = s }
 }

--- a/internal/gateway/openclaw.go
+++ b/internal/gateway/openclaw.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -56,7 +57,7 @@ type DeviceInfo struct {
 type Signer interface {
 	DeviceID() string
 	PublicKeyBase64() string
-	Sign(nonce string) (signature string, signedAt int64, err error)
+	Sign(data []byte) []byte
 }
 
 type clientInfo struct {
@@ -195,6 +196,12 @@ func (oc *OpenClaw) Connect(ctx context.Context) error {
 		return fmt.Errorf("parse challenge frame: %w", err)
 	}
 
+	clientID := "gateway-client"
+	clientMode := "backend"
+	role := "operator"
+	scopes := []string{"operator.read", "operator.write"}
+	platform := runtime.GOOS
+
 	// Build device identity if a signer is configured.
 	var deviceInfo *DeviceInfo
 	if oc.signer != nil {
@@ -204,16 +211,13 @@ func (oc *OpenClaw) Connect(ctx context.Context) error {
 			oc.conn = nil
 			return fmt.Errorf("gateway challenge missing nonce")
 		}
-		sig, signedAt, err := oc.signer.Sign(nonce)
-		if err != nil {
-			_ = conn.Close()
-			oc.conn = nil
-			return fmt.Errorf("sign challenge nonce: %w", err)
-		}
+		signedAt := time.Now().UnixMilli()
+		payload := buildDeviceAuthPayloadV3(oc.signer.DeviceID(), clientID, clientMode, role, oc.token, scopes, signedAt, nonce, platform, "")
+		sig := oc.signer.Sign([]byte(payload))
 		deviceInfo = &DeviceInfo{
 			ID:        oc.signer.DeviceID(),
 			PublicKey: oc.signer.PublicKeyBase64(),
-			Signature: sig,
+			Signature: base64.RawURLEncoding.EncodeToString(sig),
 			SignedAt:  signedAt,
 			Nonce:     nonce,
 		}
@@ -228,18 +232,18 @@ func (oc *OpenClaw) Connect(ctx context.Context) error {
 			MinProtocol: 3,
 			MaxProtocol: 3,
 			Client: clientInfo{
-				ID:          "gateway-client",
+				ID:          clientID,
 				DisplayName: "Kapso WhatsApp Bridge",
 				Version:     Version,
-				Platform:    runtime.GOOS,
-				Mode:        "backend",
+				Platform:    platform,
+				Mode:        clientMode,
 			},
 			Auth: authInfo{
 				Token: oc.token,
 			},
 			Device: deviceInfo,
-			Role:   "operator",
-			Scopes: []string{"operator.read", "operator.write"},
+			Role:   role,
+			Scopes: scopes,
 		},
 	}
 
@@ -496,6 +500,26 @@ func (oc *OpenClaw) Close() error {
 		<-done
 	}
 	return err
+}
+
+func buildDeviceAuthPayloadV3(deviceID, clientID, clientMode, role, token string, scopes []string, signedAtMs int64, nonce, platform, deviceFamily string) string {
+	return strings.Join([]string{
+		"v3",
+		deviceID,
+		clientID,
+		clientMode,
+		role,
+		strings.Join(scopes, ","),
+		fmt.Sprintf("%d", signedAtMs),
+		token,
+		nonce,
+		normalizeMetadata(platform),
+		normalizeMetadata(deviceFamily),
+	}, "|")
+}
+
+func normalizeMetadata(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
 }
 
 // getSessionFile reads sessions.json and returns the path to the active

--- a/internal/gateway/openclaw_test.go
+++ b/internal/gateway/openclaw_test.go
@@ -20,16 +20,15 @@ import (
 type mockSigner struct {
 	id    string
 	pubK  string
-	sig   string
-	ts    int64
+	sig   []byte
 	nonce string
 }
 
 func (m *mockSigner) DeviceID() string        { return m.id }
 func (m *mockSigner) PublicKeyBase64() string { return m.pubK }
-func (m *mockSigner) Sign(nonce string) (string, int64, error) {
-	m.nonce = nonce
-	return m.sig, m.ts, nil
+func (m *mockSigner) Sign(data []byte) []byte {
+	m.nonce = string(data)
+	return m.sig
 }
 
 // newTestOpenClaw creates an OpenClaw gateway pointed at the given WebSocket URL.
@@ -284,8 +283,7 @@ func TestConnectIncludesDeviceIdentity(t *testing.T) {
 	signer := &mockSigner{
 		id:   "device-fingerprint-abc",
 		pubK: "dGVzdC1wdWJsaWMta2V5",
-		sig:  "dGVzdC1zaWduYXR1cmU=",
-		ts:   1737264000000,
+		sig:  []byte("test-signature"),
 	}
 
 	client := newTestOpenClaw(wsURL, "test-token", signer)
@@ -329,18 +327,18 @@ func TestConnectIncludesDeviceIdentity(t *testing.T) {
 	if d.PublicKey != "dGVzdC1wdWJsaWMta2V5" {
 		t.Errorf("device.publicKey: got %q, want %q", d.PublicKey, "dGVzdC1wdWJsaWMta2V5")
 	}
-	if d.Signature != "dGVzdC1zaWduYXR1cmU=" {
-		t.Errorf("device.signature: got %q, want %q", d.Signature, "dGVzdC1zaWduYXR1cmU=")
+	if d.Signature != "dGVzdC1zaWduYXR1cmU" {
+		t.Errorf("device.signature: got %q, want %q", d.Signature, "dGVzdC1zaWduYXR1cmU")
 	}
-	if d.SignedAt != 1737264000000 {
-		t.Errorf("device.signedAt: got %d, want %d", d.SignedAt, 1737264000000)
+	if d.SignedAt <= 0 {
+		t.Errorf("device.signedAt: got %d, want positive timestamp", d.SignedAt)
 	}
 	if d.Nonce != challengeNonce {
 		t.Errorf("device.nonce: got %q, want %q", d.Nonce, challengeNonce)
 	}
 
-	if signer.nonce != challengeNonce {
-		t.Errorf("signer received nonce %q, want %q", signer.nonce, challengeNonce)
+	if !strings.Contains(signer.nonce, challengeNonce) {
+		t.Errorf("signer payload should contain nonce %q, got %q", challengeNonce, signer.nonce)
 	}
 }
 
@@ -445,7 +443,7 @@ func TestConnectWithSignerButNoNonceErrors(t *testing.T) {
 	defer close(done)
 
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
-	signer := &mockSigner{id: "test", pubK: "dGVzdA==", sig: "c2ln", ts: 1}
+	signer := &mockSigner{id: "test", pubK: "dGVzdA==", sig: []byte("sig")}
 	client := newTestOpenClaw(wsURL, "test-token", signer)
 
 	err := client.Connect(context.Background())

--- a/internal/gateway/openclaw_test.go
+++ b/internal/gateway/openclaw_test.go
@@ -21,13 +21,13 @@ type mockSigner struct {
 	id    string
 	pubK  string
 	sig   []byte
-	nonce string
+	lastPayload string
 }
 
 func (m *mockSigner) DeviceID() string        { return m.id }
 func (m *mockSigner) PublicKeyBase64() string { return m.pubK }
 func (m *mockSigner) Sign(data []byte) []byte {
-	m.nonce = string(data)
+	m.lastPayload = string(data)
 	return m.sig
 }
 
@@ -337,8 +337,8 @@ func TestConnectIncludesDeviceIdentity(t *testing.T) {
 		t.Errorf("device.nonce: got %q, want %q", d.Nonce, challengeNonce)
 	}
 
-	if !strings.Contains(signer.nonce, challengeNonce) {
-		t.Errorf("signer payload should contain nonce %q, got %q", challengeNonce, signer.nonce)
+	if !strings.Contains(signer.lastPayload, challengeNonce) {
+		t.Errorf("signer payload should contain nonce %q, got %q", challengeNonce, signer.lastPayload)
 	}
 }
 


### PR DESCRIPTION
## Summary

OpenClaw gateway v2026.3.24 requires protocol v3 with device identity, but the bridge was sending protocol v3 without a device signer causing `NOT_PAIRED` rejection on every connect.

**Changes:**
- Rewrite `internal/device` from ECDSA P-256 to Ed25519 (matching gateway's `crypto.verify` expectations)
- Sign the v3 pipe-delimited auth payload (`v3|deviceId|clientId|mode|role|scopes|ts|token|nonce|platform|deviceFamily`) instead of just the nonce
- Use base64url encoding for signature and public key
- Wire device identity into `gateway.New()` via `WithSigner` option
- Expand `~` in TOML config paths (sessions_json, state dir, transcribe paths)
- Auto-migrate incompatible ECDSA keys — removes old key and regenerates Ed25519 on startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added device identity signing support for gateway authentication.

* **Improvements**
  * Expand home-directory paths in configuration fields.
  * Device identity now uses a modern Ed25519 keypair with automatic handling/regeneration and URL-safe public-key encoding.
  * Gateway initialization accepts an optional signer and uses identity-based signing for connection handshakes.

* **Tests**
  * Updated tests to validate Ed25519 signing and new handshake payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->