### PR TITLE
fix: advertise gateway protocol 4 in connect handshake (closes #36)

### DIFF
--- a/internal/gateway/openclaw.go
+++ b/internal/gateway/openclaw.go
@@ -235,8 +235,13 @@ func (oc *OpenClaw) Connect(ctx context.Context) error {
 		ID:     oc.nextID(),
 		Method: "connect",
 		Params: connectParams{
+			// Advertise a protocol range. The gateway accepts the connection
+			// when this range includes its PROTOCOL_VERSION. OpenClaw
+			// 2026.5.27 requires protocol 4; older gateways speak 3. The
+			// device-auth payload (v3, see buildDeviceAuthPayloadV3) is
+			// unchanged across both, so the [3,4] range is backward compatible.
 			MinProtocol: 3,
-			MaxProtocol: 3,
+			MaxProtocol: 4,
 			Client: clientInfo{
 				ID:          clientID,
 				DisplayName: "Kapso WhatsApp Bridge",

--- a/internal/gateway/openclaw_test.go
+++ b/internal/gateway/openclaw_test.go
@@ -318,6 +318,24 @@ func TestConnectIncludesDeviceIdentity(t *testing.T) {
 		t.Fatalf("unmarshal connect frame: %v", err)
 	}
 
+	// Regression for #36: the gateway (OpenClaw 2026.5.27+) requires protocol
+	// 4, accepting a connect only when the advertised range includes it.
+	var proto struct {
+		Params struct {
+			MinProtocol int `json:"minProtocol"`
+			MaxProtocol int `json:"maxProtocol"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(raw, &proto); err != nil {
+		t.Fatalf("unmarshal protocol range: %v", err)
+	}
+	if proto.Params.MaxProtocol < 4 {
+		t.Errorf("maxProtocol: got %d, want >= 4 (gateway requires protocol 4)", proto.Params.MaxProtocol)
+	}
+	if proto.Params.MinProtocol > 4 {
+		t.Errorf("minProtocol: got %d, want <= 4", proto.Params.MinProtocol)
+	}
+
 	if frame.Params.Device == nil {
 		t.Fatal("device field missing from connect request")
 	}


### PR DESCRIPTION
## Summary

Fixes #36 — `kapso-whatsapp-bridge` fails to start against OpenClaw 2026.5.27 with `PROTOCOL_MISMATCH`.

OpenClaw 2026.5.27 raised its gateway protocol to **4** (`PROTOCOL_VERSION = 4`). The server accepts a connect handshake only when the client's advertised range includes its version:

```
supportsCurrentProtocol = maxProtocol >= 4 && minProtocol <= 4
```

The bridge hardcoded `minProtocol: 3, maxProtocol: 3`, so `3 >= 4` was false and every connect was rejected:

```
connect rejected: {"code":"PROTOCOL_MISMATCH","clientMinProtocol":3,"clientMaxProtocol":3,"expectedProtocol":4,"minimumProbeProtocol":4}
```

## Fix

Advertise `minProtocol: 3, maxProtocol: 4` in the connect request (`internal/gateway/openclaw.go`).

**No device-auth changes are needed.** Verified against the OpenClaw source that protocol 4 did **not** change the handshake auth:
- The gateway's `resolveDeviceSignaturePayloadVersion` still verifies the **v3** pipe-delimited payload (`v3|deviceId|clientId|clientMode|role|scopes|signedAtMs|token|nonce|platform|deviceFamily`) — byte-identical to what `buildDeviceAuthPayloadV3` already produces.
- The `device` connect-object schema is unchanged (`{id, publicKey, signature, signedAt, nonce}`).

Advertising the `[3, 4]` range (rather than pinning to 4) keeps the bridge compatible with older protocol-3 gateways.

## Tests

Added a protocol-range assertion to `TestConnectIncludesDeviceIdentity`: the advertised range must include 4 (`maxProtocol >= 4 && minProtocol <= 4`), so a future downgrade is caught.

`go build ./...`, `go test ./...`, `go vet ./...`, and `gofmt` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended protocol support to ensure seamless compatibility with current and future gateway versions, enabling continued device authentication and communication across firmware releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Enriquefft/openclaw-kapso-whatsapp/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->